### PR TITLE
Fix #7 Return formatted message if format string

### DIFF
--- a/logzio/handler.py
+++ b/logzio/handler.py
@@ -39,7 +39,7 @@ class LogzioHandler(logging.Handler):
             "path_name": message.pathname,
             "log_level": message.levelname,
             "type": self.logzio_type,
-            "message": message.msg,
+            "message": message.getMessage(),
             "@timestamp": timestamp
         }
 

--- a/tests/test_logzioHandler.py
+++ b/tests/test_logzioHandler.py
@@ -77,6 +77,34 @@ class TestLogzioHandler(TestCase):
              }
         )
 
+    def test_format_string_message(self):
+        record = logging.LogRecord(
+            name='my-logger',
+            level=0,
+            pathname='handler_test.py',
+            lineno=10,
+            msg="this is a test: %s.",
+            args=('moo',),
+            exc_info=None,
+            func='test_json'
+        )
+
+        formatted_message = self.handler.format_message(record)
+        formatted_message["@timestamp"] = None
+
+        self.assertDictEqual(
+            formatted_message,
+            {
+                '@timestamp': None,
+                'line_number': 10,
+                'log_level': 'NOTSET',
+                'logger': 'my-logger',
+                'message': 'this is a test: moo.',
+                'path_name': 'handler_test.py',
+                'type': 'python'
+             }
+        )
+
     def test_exc(self):
         try:
             raise ValueError("oops.")


### PR DESCRIPTION
Currently logging with:
```
logger.info('hello %s', 'world')
```
will send the string "hello %s" to logz.io instead of "hello world"

This commit fixes this situation.

Fixes #7 