### PR TITLE
Ensure sending thread is alive before appending log message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 
+*egg-info/

--- a/logzio/sender.py
+++ b/logzio/sender.py
@@ -34,9 +34,6 @@ class LogzioSender:
 
         # Create a queue to hold logs
         self.queue = queue.Queue()
-        self._initialize_sending_thread()
-
-    def _initialize_sending_thread(self):
         self.sending_thread = Thread(target=self._drain_queue)
         self.sending_thread.daemon = False
         self.sending_thread.name = "logzio-sending-thread"
@@ -45,7 +42,7 @@ class LogzioSender:
     def append(self, logs_message):
         # Queue lib is thread safe, no issue here
         if not self.sending_thread.is_alive():
-            self._initialize_sending_thread()
+            self.sending_thread.start()
         self.queue.put(json.dumps(logs_message))
 
     def flush(self):

--- a/logzio/sender.py
+++ b/logzio/sender.py
@@ -34,7 +34,9 @@ class LogzioSender:
 
         # Create a queue to hold logs
         self.queue = queue.Queue()
+        self._initialize_sending_thread()
 
+    def _initialize_sending_thread(self):
         self.sending_thread = Thread(target=self._drain_queue)
         self.sending_thread.daemon = False
         self.sending_thread.name = "logzio-sending-thread"
@@ -42,6 +44,8 @@ class LogzioSender:
 
     def append(self, logs_message):
         # Queue lib is thread safe, no issue here
+        if not self.sending_thread.is_alive():
+            self._initialize_sending_thread()
         self.queue.put(json.dumps(logs_message))
 
     def flush(self):

--- a/logzio/sender.py
+++ b/logzio/sender.py
@@ -34,15 +34,19 @@ class LogzioSender:
 
         # Create a queue to hold logs
         self.queue = queue.Queue()
+        self._initialize_sending_thread()
+
+    def _initialize_sending_thread(self):
         self.sending_thread = Thread(target=self._drain_queue)
         self.sending_thread.daemon = False
         self.sending_thread.name = "logzio-sending-thread"
         self.sending_thread.start()
 
     def append(self, logs_message):
-        # Queue lib is thread safe, no issue here
         if not self.sending_thread.is_alive():
-            self.sending_thread.start()
+            self._initialize_sending_thread()
+
+        # Queue lib is thread safe, no issue here
         self.queue.put(json.dumps(logs_message))
 
     def flush(self):

--- a/tests/mockLogzioListener/listener.py
+++ b/tests/mockLogzioListener/listener.py
@@ -73,7 +73,7 @@ class MockLogzioListener:
         return len(self.logs_list)
 
     def clear_logs_buffer(self):
-        self.logs_list = []
+        self.logs_list[:] = []
 
     def set_server_error(self):
         self.persistent_flags.set_server_error()

--- a/tests/test_logzioSender.py
+++ b/tests/test_logzioSender.py
@@ -109,13 +109,21 @@ class TestLogzioSender(TestCase):
 
     def test_can_send_after_fork(self):
         childpid = os.fork()
-        log_message = 'logged from child process'
+        child_log_message = 'logged from child process'
+        parent_log_message = 'logged from parent process'
 
         if childpid == 0:
             # Log from the child process
-            self.logger.info(log_message)
+            self.logger.info(child_log_message)
             time.sleep(self.logs_drain_timeout * 2)
             os._exit(0)
         # Wait for the child process to finish
         os.waitpid(childpid, 0)
-        self.assertTrue(self.logzio_listener.find_log(log_message))
+
+        # log from the parent process
+        self.logger.info(parent_log_message)
+        time.sleep(self.logs_drain_timeout * 2)
+
+        # Ensure listener receive all log messages
+        self.assertTrue(self.logzio_listener.find_log(child_log_message))
+        self.assertTrue(self.logzio_listener.find_log(parent_log_message))

--- a/tests/test_logzioSender.py
+++ b/tests/test_logzioSender.py
@@ -106,3 +106,16 @@ class TestLogzioSender(TestCase):
         with open(failure_files[0], "r") as f:
             line = f.readline()
             self.assertTrue(log_message in line)
+
+    def test_can_send_after_fork(self):
+        childpid = os.fork()
+        log_message = 'logged from child process'
+
+        if childpid == 0:
+            # Log from the child process
+            self.logger.info(log_message)
+            time.sleep(self.logs_drain_timeout * 2)
+            os._exit(0)
+        # Wait for the child process to finish
+        os.waitpid(childpid, 0)
+        self.assertTrue(self.logzio_listener.find_log(log_message))

--- a/tests/test_logzioSender.py
+++ b/tests/test_logzioSender.py
@@ -21,6 +21,7 @@ def _find(pattern, path):
 class TestLogzioSender(TestCase):
     def setUp(self):
         self.logzio_listener = listener.MockLogzioListener()
+        self.logzio_listener.clear_logs_buffer()
         self.logzio_listener.clear_server_error()
         self.logs_drain_timeout = 1
 


### PR DESCRIPTION
Hi, thanks for the work you've put into this handler.

We ran into issues where logs from a celery-django project were not being sent using this handler.

It appears this is because the logging is configured (and the sending thread created) when the celery worker process initializes. The worker is forked for using the prefork concurrency method, leaving the child processes with no access to the sending thread.

This resolves the issue, hopefully without introducing new ones. Looking forward to your feedback