### PR TITLE
Add support for `pypy` and `pypy3` interpreter and remove support for python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
+    - python: pypy2.7
+      env: TOXENV=pypy27
+    - python: pypy3.5
+      env: TOXENV=pypy35
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - python: pypy2.7
+    - python: pypy
       env: TOXENV=pypy27
     - python: pypy3.5
-      env: TOXENV=pypy35
+      env: TOXENV=pypy3
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
       env: TOXENV=py3flake8
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.3
-      env: TOXENV=py33
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - python: pypy2.7
+    - python: pypy
       env: TOXENV=pypy
     - python: pypy3.5
       env: TOXENV=pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - python: pypy
-      env: TOXENV=pypy27
+    - python: pypy2.7
+      env: TOXENV=pypy
     - python: pypy3.5
       env: TOXENV=pypy3
 

--- a/logzio/handler.py
+++ b/logzio/handler.py
@@ -32,6 +32,9 @@ class LogzioHandler(logging.Handler):
             backup_logs=backup_logs)
         logging.Handler.__init__(self)
 
+    def __del__(self):
+        del self.logzio_sender
+
     def extra_fields(self, message):
 
         not_allowed_keys = (

--- a/logzio/sender.py
+++ b/logzio/sender.py
@@ -48,6 +48,11 @@ class LogzioSender:
         self.queue = queue.Queue()
         self._initialize_sending_thread()
 
+    def __del__(self):
+        del self.logger
+        del self.backup_logs
+        del self.queue
+
     def _initialize_sending_thread(self):
         self.sending_thread = Thread(target=self._drain_queue)
         self.sending_thread.daemon = False
@@ -152,6 +157,8 @@ class LogzioSender:
                     'Could not send logs to Logz.io after %s tries, '
                     'backing up to local file system', number_of_retries)
                 backup_logs(logs_list, self.logger)
+
+            del logs_list
 
     def _get_messages_up_to_max_allowed_size(self):
         logs_list = []

--- a/logzio/sender.py
+++ b/logzio/sender.py
@@ -156,7 +156,12 @@ class LogzioSender:
         current_size = 0
         while not self.queue.empty():
             current_log = self.queue.get()
-            current_size += sys.getsizeof(current_log)
+            try:
+                current_size += sys.getsizeof(current_log)
+            except TypeError:
+                # pypy do not support sys.getsizeof
+                current_size += len(current_log) * 4
+
             logs_list.append(current_log)
             if current_size >= MAX_BULK_SIZE_IN_BYTES:
                 break

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.7.2
-envlist = flake8, py3flake8, py27, py33, py34, py35, py36, pypy, pypy3
+envlist = flake8, py3flake8, py27, py34, py35, py36, pypy, pypy3
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.7.2
-envlist = flake8, py3flake8, py27, py33, py34, py35, py36, pypy27, pypy35
+envlist = flake8, py3flake8, py27, py33, py34, py35, py36, pypy, pypy3
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.7.2
-envlist = flake8, py3flake8, py27, py33, py34, py35, py36
+envlist = flake8, py3flake8, py27, py33, py34, py35, py36, pypy27, pypy35
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
This fixes #32 

Since tox do not support python3.3 I've also removed it from travis and tox configuration.