### PR TITLE
Add flag to disable the local backup of logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ format={"additional_field": "value"}
  - Time to sleep between draining attempts (defaults to "3")
  - Logz.io Listener address (defaults to "https://listener.logz.io:8071")
  - Debug flag. Set to True, will print debug messages to stdout. (defaults to "False")
+ - Backup logs flag. Set to False, will disable the local backup of logs in case of failure. (defaults to "True")
 
  Please note, that you have to configure those parameters by this exact order.
  i.e. you cannot set Debug to true, without configuring all of the previous parameters as well.

--- a/logzio/handler.py
+++ b/logzio/handler.py
@@ -16,7 +16,8 @@ class LogzioHandler(logging.Handler):
                  logzio_type="python",
                  logs_drain_timeout=3,
                  url="https://listener.logz.io:8071",
-                 debug=False):
+                 debug=False,
+                 backup_logs=True):
 
         if not token:
             raise LogzioException('Logz.io Token must be provided')
@@ -27,7 +28,8 @@ class LogzioHandler(logging.Handler):
             token=token,
             url=url,
             logs_drain_timeout=logs_drain_timeout,
-            debug=debug)
+            debug=debug,
+            backup_logs=backup_logs)
         logging.Handler.__init__(self)
 
     def extra_fields(self, message):

--- a/logzio/sender.py
+++ b/logzio/sender.py
@@ -32,11 +32,13 @@ class LogzioSender:
     def __init__(self,
                  token, url='https://listener.logz.io:8071',
                  logs_drain_timeout=5,
-                 debug=False):
+                 debug=False,
+                 backup_logs=True):
         self.token = token
         self.url = '{}/?token={}'.format(url, token)
         self.logs_drain_timeout = logs_drain_timeout
         self.logger = get_logger(debug)
+        self.backup_logs = backup_logs
 
         # Function to see if the main thread is alive
         self.is_main_thread_active = lambda: any(
@@ -144,7 +146,7 @@ class LogzioSender:
                     sleep(sleep_between_retries)
                     sleep_between_retries *= 2
 
-            if should_backup_to_disk:
+            if should_backup_to_disk and self.backup_logs:
                 # Write to file
                 self.logger.info(
                     'Could not send logs to Logz.io after %s tries, '

--- a/tests/test_logzioSender.py
+++ b/tests/test_logzioSender.py
@@ -108,6 +108,20 @@ class TestLogzioSender(TestCase):
             line = f.readline()
             self.assertTrue(log_message in line)
 
+    def test_local_file_backup_disabled(self):
+        log_message = "Backup to local filesystem"
+        self.logzio_listener.set_server_error()
+        self.logger.handlers[0].logzio_sender.backup_logs = False
+        self.logger.info(log_message)
+
+        # Make sure no file is present
+        self.assertEqual(len(_find("logzio-failures-*.txt", ".")), 0)
+
+        time.sleep(2 * 2 * 2 * 2 * 2)  # All of the retries
+
+        # Make sure no file was created
+        self.assertEqual(len(_find("logzio-failures-*.txt", ".")), 0)
+
     def test_can_send_after_fork(self):
         childpid = os.fork()
         child_log_message = 'logged from child process'


### PR DESCRIPTION
This adds a flag to disable the local backup of lofs. This is very important for some application like IoT devices where we don't want to fill the disk if the logs can't be sent to logz.
Fixes #35 