### PR TITLE
Add timeout for requests.post() operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ format={"additional_field": "value"}
  - Logz.io Listener address (defaults to "https://listener.logz.io:8071")
  - Debug flag. Set to True, will print debug messages to stdout. (defaults to "False")
  - Backup logs flag. Set to False, will disable the local backup of logs in case of failure. (defaults to "True")
+ - Network timeout, in seconds, int or float, for sending the logs to logz.io. (defaults to 10)
 
  Please note, that you have to configure those parameters by this exact order.
  i.e. you cannot set Debug to true, without configuring all of the previous parameters as well.
@@ -124,7 +125,8 @@ LOGGING = {
             'logzio_type': "django",
             'logs_drain_timeout': 5,
             'url': 'https://listener.logz.io:8071',
-            'debug': True
+            'debug': True,
+            'network_timeout': 10,
         },
     },
     'loggers': {

--- a/logzio/handler.py
+++ b/logzio/handler.py
@@ -17,7 +17,8 @@ class LogzioHandler(logging.Handler):
                  logs_drain_timeout=3,
                  url="https://listener.logz.io:8071",
                  debug=False,
-                 backup_logs=True):
+                 backup_logs=True,
+                 network_timeout=10.0):
 
         if not token:
             raise LogzioException('Logz.io Token must be provided')
@@ -29,7 +30,8 @@ class LogzioHandler(logging.Handler):
             url=url,
             logs_drain_timeout=logs_drain_timeout,
             debug=debug,
-            backup_logs=backup_logs)
+            backup_logs=backup_logs,
+            network_timeout=network_timeout)
         logging.Handler.__init__(self)
 
     def extra_fields(self, message):

--- a/logzio/sender.py
+++ b/logzio/sender.py
@@ -33,12 +33,14 @@ class LogzioSender:
                  token, url='https://listener.logz.io:8071',
                  logs_drain_timeout=5,
                  debug=False,
-                 backup_logs=True):
+                 backup_logs=True,
+                 network_timeout=10.0):
         self.token = token
         self.url = '{}/?token={}'.format(url, token)
         self.logs_drain_timeout = logs_drain_timeout
         self.logger = get_logger(debug)
         self.backup_logs = backup_logs
+        self.network_timeout = network_timeout
 
         # Function to see if the main thread is alive
         self.is_main_thread_active = lambda: any(
@@ -104,7 +106,8 @@ class LogzioSender:
                 should_retry = False
                 try:
                     response = requests.post(
-                        self.url, headers=headers, data='\n'.join(logs_list))
+                        self.url, headers=headers, data='\n'.join(logs_list),
+                        timeout=self.network_timeout)
                     if response.status_code != 200:
                         if response.status_code == 400:
                             self.logger.info(


### PR DESCRIPTION
Like all network operations, performing the POST request may fail for various
reasons. When no response from the remote end is received, a requests.post()
call may never return, leading to an unbounded increase in the sender queue.

To remedy such situations let's add a timeout argument to the requests call and
make it configurable, to be adaptable for different environments.

For more information see
https://2.python-requests.org/en/master/user/quickstart/#timeouts