### PR TITLE
Version update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: python
 matrix:
   include:
     - python: 3.8
+      env: TOXENV=flake8
+    - python: 3.8
       env: TOXENV=py3flake8
     - python: 3.5
       env: TOXENV=py35

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,8 @@ language: python
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=flake8
     - python: 3.8
       env: TOXENV=py3flake8
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ pip install logzio-python-handler
 ```
 
 ## Tested Python Versions
+<table><tr><th>
+
+### Deprecation announcement
+As of version 2.1.0, this project will no long support Python 2.7 & 3.4. We recommend migrating your projects to Python 3.5+ as soon as possible. We'll be happy to answer any questions you have in [a GitHub issue](https://github.com/logzio/logzio-python-handler/issues). <br><br>
+Thanks! <br>
+The Logz.io Integrations team
+</th></tr></table>
+
 Travis CI will build this handler and test against:
-  - "2.7" 
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
@@ -164,6 +170,8 @@ LOGGING = {
 - appname - Your django app
 
 ## Release Notes
+- 2.1.0
+    - Deprecated `python2.7` & `python3.4`
 - 2.0.15
     - Added flusher decorator for serverless platforms(@mcmasty)
     - Add support for `python3.7` and `python3.8` 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 [![PyPI version](https://badge.fury.io/py/logzio-python-handler.svg)](https://badge.fury.io/py/logzio-python-handler) [![Build Status](https://travis-ci.org/logzio/logzio-python-handler.svg?branch=master)](https://travis-ci.org/logzio/logzio-python-handler)
 
 # The Logz.io Python Handler
+
+<table><tr><th>
+
+### Deprecation announcement
+Version 2.1.0 of this project ends support for Python 2.7 & 3.4. We recommend migrating your projects to Python 3.5 or newer as soon as possible. We'll be happy to answer any questions you have in [a GitHub issue](https://github.com/logzio/logzio-python-handler/issues).
+Thanks! <br>
+The Logz.io Integrations team
+</th></tr></table>
+
 This is a Python handler that sends logs in bulk over HTTPS to Logz.io.
 The handler uses a subclass named LogzioSender (which can be used without this handler as well, to ship raw data).
 The LogzioSender class opens a new Thread, that consumes from the logs queue. Each iteration (its frequency of which can be configured by the logs_drain_timeout parameter), will try to consume the queue in its entirety.
@@ -8,20 +17,13 @@ Logs will get divided into separate bulks, based on their size.
 LogzioSender will check if the main thread is alive. In case the main thread quits, it will try to consume the queue one last time, and then exit. So your program can hang for a few seconds, until the logs are drained.
 In case the logs failed to be sent to Logz.io after a couple of tries, they will be written to the local file system. You can later upload them to Logz.io using curl.
 
+
 ## Installation
 ```bash
 pip install logzio-python-handler
 ```
 
 ## Tested Python Versions
-<table><tr><th>
-
-### Deprecation announcement
-As of version 2.1.0, this project will no long support Python 2.7 & 3.4. We recommend migrating your projects to Python 3.5+ as soon as possible. We'll be happy to answer any questions you have in [a GitHub issue](https://github.com/logzio/logzio-python-handler/issues). <br><br>
-Thanks! <br>
-The Logz.io Integrations team
-</th></tr></table>
-
 Travis CI will build this handler and test against:
   - "3.5"
   - "3.6"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Deprecation announcement
 
-Version 2.1.0 of this project ends support for Python 2.7, 3.3, 3.4. We recommend migrating your projects to Python 3.5 or newer as soon as possible. We'll be happy to answer any questions you have in [a GitHub issue](https://github.com/logzio/logzio-python-handler/issues).
+Version 2.1.0 of this project ends support for Python 2.7, 3.3, and 3.4. We recommend migrating your projects to Python 3.5 or newer as soon as possible. We'll be happy to answer any questions you have in [a GitHub issue](https://github.com/logzio/logzio-python-handler/issues).
 
 Thanks! <br>
 The Logz.io Integrations team

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Deprecation announcement
 
-Version 2.1.0 of this project ends support for Python 2.7 & 3.4. We recommend migrating your projects to Python 3.5 or newer as soon as possible. We'll be happy to answer any questions you have in [a GitHub issue](https://github.com/logzio/logzio-python-handler/issues).
+Version 2.1.0 of this project ends support for Python 2.7, 3.3, 3.4. We recommend migrating your projects to Python 3.5 or newer as soon as possible. We'll be happy to answer any questions you have in [a GitHub issue](https://github.com/logzio/logzio-python-handler/issues).
 
 Thanks! <br>
 The Logz.io Integrations team
@@ -34,8 +34,6 @@ Travis CI will build this handler and test against:
   - "3.8"
 
 We can't ensure compatibility to any other version, as we can't test it automatically.
-
-**Note**: The Logz.io Python Handler no longer tests Python 3.3 (which was [end-of-lifed](https://www.python.org/dev/peps/pep-0398/#id11) in 2017).
 
 To run tests:
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@
 <table><tr><th>
 
 ### Deprecation announcement
+
 Version 2.1.0 of this project ends support for Python 2.7 & 3.4. We recommend migrating your projects to Python 3.5 or newer as soon as possible. We'll be happy to answer any questions you have in [a GitHub issue](https://github.com/logzio/logzio-python-handler/issues).
+
 Thanks! <br>
 The Logz.io Integrations team
+
 </th></tr></table>
 
 This is a Python handler that sends logs in bulk over HTTPS to Logz.io.

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license="Apache License 2",
     packages=find_packages(),
     install_requires=[
-        "requests"
+        "requests>=2.23.0"
     ],
     test_requires=[
         "future"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 setup(
     name="logzio-python-handler",
-    version='2.0.15',
+    version='2.1.0',
     description="Logging handler to send logs to your Logz.io account with bulk SSL",
     keywords="logging handler logz.io bulk https",
     author="roiravhon",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.7.2
-envlist = py3flake8, py35, py36, py37, py38, pypy, pypy3
+envlist = flake8, py3flake8, py35, py36, py37, py38, pypy, pypy3
 skip_missing_interpreters = true
 
 [testenv]
@@ -11,6 +11,11 @@ deps =
     pytest-cov
 passenv = CI TRAVIS TRAVIS_*
 commands = pytest --cov-report term-missing --cov logzio tests -v
+
+[testenv:flake8]
+basepython = python3.8
+deps = flake8
+commands = flake8 logzio
 
 [testenv:py3flake8]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.7.2
-envlist = flake8, py3flake8, py27, py34, py35, py36, py37, py38, pypy, pypy3
+envlist = py3flake8, py35, py36, py37, py38, pypy, pypy3
 skip_missing_interpreters = true
 
 [testenv]
@@ -11,11 +11,6 @@ deps =
     pytest-cov
 passenv = CI TRAVIS TRAVIS_*
 commands = pytest --cov-report term-missing --cov logzio tests -v
-
-[testenv:flake8]
-basepython = python2.7
-deps = flake8
-commands = flake8 logzio
 
 [testenv:py3flake8]
 basepython = python3.8


### PR DESCRIPTION
- Solved [whitesource security issue](https://github.com/logzio/logzio-python-handler/issues/51).
- As of this version (2.1.0) forward, python2.7 & python3.4 are not supported.