### PR TITLE
Fix message formatting while handling exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ LOGGING = {
 Please note that if you are using `python 3.8`, it is preferred to use the `logging.config.dictConfig` method, as mentioned in [python's documentation](https://docs.python.org/3/library/logging.config.html#configuration-file-format).
 
 ## Release Notes
+
+- 4.0.2
+  - Fix bug for logging exceptions ([#76](https://github.com/logzio/logzio-python-handler/pull/76))
 - 4.0.1
   - Updated `protobuf>=3.20.2`.
   - Added dependency `setuptools>=65.5.1`
@@ -262,13 +265,15 @@ Please note that if you are using `python 3.8`, it is preferred to use the `logg
 - 4.0.0
   - Add ability to automatically attach trace context to the logs.
 
-- 3.1.1
-  - Bug fixes (issue #68, exception message formatting)
-  - Added CI: Tests and Auto release 
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>
 
+
+- 3.1.1
+  - Bug fixes (issue #68, exception message formatting)
+  - Added CI: Tests and Auto release
+  
 - 3.1.0
     - Bug fixes
     - Retry number and timeout is now configurable

--- a/logzio/handler.py
+++ b/logzio/handler.py
@@ -79,6 +79,8 @@ class LogzioHandler(logging.Handler):
     def format(self, record):
         message = super(LogzioHandler, self).format(record)
         try:
+            if record.exc_info:
+                message = message.split("\nTraceback")[0]  # only keep the original formatted message part
             return json.loads(message)
         except (TypeError, ValueError):
             return message

--- a/logzio/handler.py
+++ b/logzio/handler.py
@@ -80,7 +80,7 @@ class LogzioHandler(logging.Handler):
         message = super(LogzioHandler, self).format(record)
         try:
             if record.exc_info:
-                message = message.split("\nTraceback")[0]  # only keep the original formatted message part
+                message = message.split("\n")[0]  # only keep the original formatted message part
             return json.loads(message)
         except (TypeError, ValueError):
             return message

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 setup(
     name="logzio-python-handler",
-    version='4.0.1',
+    version='4.0.2',
     description="Logging handler to send logs to your Logz.io account with bulk SSL",
     keywords="logging handler logz.io bulk https",
     author="roiravhon",

--- a/tests/test_logzioHandler.py
+++ b/tests/test_logzioHandler.py
@@ -137,7 +137,10 @@ class TestLogzioHandler(TestCase):
             }
         )
 
-    def test_exc(self):
+    def test_exception(self):
+        formatter = logging.Formatter('{"tags": ["staging", "experimental"], "appname": "my-service"}', validate=False)
+        self.handler.setFormatter(formatter)
+        
         try:
             raise ValueError("oops.")
         except:
@@ -163,13 +166,15 @@ class TestLogzioHandler(TestCase):
         self.assertDictEqual(
             {
                 '@timestamp': None,
+                'appname': 'my-service',
                 'line_number': 10,
                 'log_level': 'NOTSET',
                 'logger': 'my-logger',
                 'message': 'exception test:',
-                'exception': 'Traceback (most recent call last):\n\n  File "", in test_exc\n    raise ValueError("oops.")\n\nValueError: oops.\n',
+                'exception': 'Traceback (most recent call last):\n\n  File "", in test_exception\n    raise ValueError("oops.")\n\nValueError: oops.\n',
                 'path_name': 'handler_test.py',
-                'type': 'python'
+                'type': 'python',
+                'tags': ['staging', 'experimental']
             },
             formatted_message
         )


### PR DESCRIPTION
Consider the following format:

```
LOGGING = {
    'version': 1,
    'disable_existing_loggers': False,
    'formatters': {
        'logzioFormat': {
            'format': '{"additional_field": "value"}',
            'validate': False
        }
    },
    'handlers': {
        'logzio': {
            'class': 'logzio.handler.LogzioHandler',
            'level': 'INFO',
            'formatter': 'logzioFormat',
            'token': '<<LOGZIO-TOKEN>>',
            'logzio_type': 'python-handler',
            'logs_drain_timeout': 5,
            'url': 'https://<<LOGZIO-URL>>:8071',
            'retries_no': 4,
            'retry_timeout': 2,
        }
    },
    'loggers': {
        '': {
            'level': 'DEBUG',
            'handlers': ['logzio'],
            'propagate': True
        }
    }
}
```

And the case, where the user logs an exception:

```
logger.exception("Something")
```

Python appends the exception traceback to the formatted message (`{"additional_field": "value"}` originally). Which would result in the logzio handler not being able to parse it as JSON, and thus not adding the additional fields to the log.