### PR TITLE
Fixed DeprecationWarning & improved code format

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,8 +1,8 @@
 name: Pypi Release
 on:
   workflow_run:
-    workflows: ["CI Tests"]
-    branches: [master]
+    workflows: [ "CI Tests" ]
+    branches: [ master ]
     types:
       - completed
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: CI Tests
-on: [push]
+on: [ push ]
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -322,6 +322,9 @@ LOGGING = {
 
 ## Release Notes
 
+- 4.1.2
+    - Fix DeprecationWarning
+    - Adjusted tests to logging:3.12
 - 4.1.1
     - Fix flusher issues with serverless
 - 4.1.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 ### Deprecation announcement
 
-Version 3.0.0 of this project ends support for Python 2.7, 3.3, and 3.4. We recommend migrating your projects to Python 3.5 or newer as soon as possible. We'll be happy to answer any questions you have in [a GitHub issue](https://github.com/logzio/logzio-python-handler/issues).
+Version 3.0.0 of this project ends support for Python 2.7, 3.3, and 3.4. We recommend migrating your projects to Python
+3.5 or newer as soon as possible. We'll be happy to answer any questions you have
+in [a GitHub issue](https://github.com/logzio/logzio-python-handler/issues).
 
 Thanks! <br>
 The Logz.io Integrations team
@@ -15,31 +17,38 @@ The Logz.io Integrations team
 
 This is a Python handler that sends logs in bulk over HTTPS to Logz.io.
 The handler uses a subclass named LogzioSender (which can be used without this handler as well, to ship raw data).
-The LogzioSender class opens a new Thread, that consumes from the logs queue. Each iteration (its frequency of which can be configured by the logs_drain_timeout parameter), will try to consume the queue in its entirety.
+The LogzioSender class opens a new Thread, that consumes from the logs queue. Each iteration (its frequency of which can
+be configured by the logs_drain_timeout parameter), will try to consume the queue in its entirety.
 Logs will get divided into separate bulks, based on their size.
-LogzioSender will check if the main thread is alive. In case the main thread quits, it will try to consume the queue one last time, and then exit. So your program can hang for a few seconds, until the logs are drained.
-In case the logs failed to be sent to Logz.io after a couple of tries, they will be written to the local file system. You can later upload them to Logz.io using curl.
-
+LogzioSender will check if the main thread is alive. In case the main thread quits, it will try to consume the queue one
+last time, and then exit. So your program can hang for a few seconds, until the logs are drained.
+In case the logs failed to be sent to Logz.io after a couple of tries, they will be written to the local file system.
+You can later upload them to Logz.io using curl.
 
 ## Installation
+
 ```bash
 pip install logzio-python-handler
 ```
 
-If you'd like to use [Trace context](#trace-context), you need to install the OpenTelemetry logging instrumentation dependency by running the following command:
+If you'd like to use [Trace context](#trace-context), you need to install the OpenTelemetry logging instrumentation
+dependency by running the following command:
 
 ```bash
 pip install logzio-python-handler[opentelemetry-logging]
 ```
+
 ## Tested Python Versions
+
 Travis CI will build this handler and test against:
-  - "3.5"
-  - "3.6"
-  - "3.7"
-  - "3.8"
-  - "3.9"
-  - "3.10"
-  - "3.11"
+
+- "3.5"
+- "3.6"
+- "3.7"
+- "3.8"
+- "3.9"
+- "3.10"
+- "3.11"
 
 We can't ensure compatibility to any other version, as we can't test it automatically.
 
@@ -53,46 +62,56 @@ $ tox
 ```
 
 ## Python configuration
+
 #### Config File
+
 ```python
 [handlers]
-keys=LogzioHandler
+keys = LogzioHandler
 
 [handler_LogzioHandler]
-class=logzio.handler.LogzioHandler
-formatter=logzioFormat
+
+
+class =logzio.handler.LogzioHandler
+
+
+formatter = logzioFormat
 
 # Parameters must be set in order. Replace these parameters with your configuration.
-args=('<<LOG-SHIPPING-TOKEN>>', '<<LOG-TYPE>>', <<TIMEOUT>>, 'https://<<LISTENER-HOST>>:8071', <<DEBUG-FLAG>>,<<NETWORKING-TIMEOUT>>,<<RETRY-LIMIT>>,<<RETRY-TIMEOUT>>)
+args = ('<<LOG-SHIPPING-TOKEN>>', '<<LOG-TYPE>>',
+        << TIMEOUT >>, 'https://<<LISTENER-HOST>>:8071', << DEBUG-FLAG >>, << NETWORKING-TIMEOUT >>, << RETRY-LIMIT >>, << RETRY-TIMEOUT >>)
 
 [formatters]
-keys=logzioFormat
+keys = logzioFormat
 
 [loggers]
-keys=root
+keys = root
 
 [logger_root]
-handlers=LogzioHandler
-level=INFO
+handlers = LogzioHandler
+level = INFO
 
 [formatter_logzioFormat]
-format={"additional_field": "value"}
+format = {"additional_field": "value"}
 ```
-*args=() arguments, by order*
- - Your logz.io token
- - Log type, for searching in logz.io (defaults to "python")
- - Time to sleep between draining attempts (defaults to "3")
- - Logz.io Listener address (defaults to "https://listener.logz.io:8071")
- - Debug flag. Set to True, will print debug messages to stdout. (defaults to "False")
- - Backup logs flag. Set to False, will disable the local backup of logs in case of failure. (defaults to "True")
- - Network timeout, in seconds, int or float, for sending the logs to logz.io. (defaults to 10)
- - Retries number (retry_no, defaults to 4).
- - Retry timeout (retry_timeout) in seconds (defaults to 2).
 
- Please note, that you have to configure those parameters by this exact order.
- i.e. you cannot set Debug to true, without configuring all of the previous parameters as well.
+*args=() arguments, by order*
+
+- Your logz.io token
+- Log type, for searching in logz.io (defaults to "python")
+- Time to sleep between draining attempts (defaults to "3")
+- Logz.io Listener address (defaults to "https://listener.logz.io:8071")
+- Debug flag. Set to True, will print debug messages to stdout. (defaults to "False")
+- Backup logs flag. Set to False, will disable the local backup of logs in case of failure. (defaults to "True")
+- Network timeout, in seconds, int or float, for sending the logs to logz.io. (defaults to 10)
+- Retries number (retry_no, defaults to 4).
+- Retry timeout (retry_timeout) in seconds (defaults to 2).
+
+Please note, that you have to configure those parameters by this exact order.
+i.e. you cannot set Debug to true, without configuring all of the previous parameters as well.
 
 #### Dict Config
+
 ```python
 LOGGING = {
     'version': 1,
@@ -125,24 +144,33 @@ LOGGING = {
     }
 }
 ```
+
 Replace:
+
 * <<LOGZIO-TOKEN>> - your logz.io account token.
-* <<LOGZIO-URL>> - logz.io url, as described [here](https://docs.logz.io/user-guide/accounts/account-region.html#regions-and-urls).
+* <<LOGZIO-URL>> - logz.io url, as
+  described [here](https://docs.logz.io/user-guide/accounts/account-region.html#regions-and-urls).
+
 #### Serverless platforms
 
-If you're using a serverless function, you'll need to import and add the LogzioFlusher annotation before your sender function. To do this, in the code sample below, uncomment the `import` statement and the `@LogzioFlusher(logger)` annotation line.  
-**Note:** For the LogzioFlusher to work properly, you'll need to make sure that the Logz.io. handler is added to the root logger. See the configuration above for an example.
+If you're using a serverless function, you'll need to import and add the LogzioFlusher annotation before your sender
+function. To do this, in the code sample below, uncomment the `import` statement and the `@LogzioFlusher(logger)`
+annotation line.  
+**Note:** For the LogzioFlusher to work properly, you'll need to make sure that the Logz.io. handler is added to the
+root logger. See the configuration above for an example.
 
 #### Dynamic Extra Fields
+
 If you prefer, you can add extra fields to your logs dynamically, and not pre-defining them in the configuration.
 This way, you can allow different logs to have different extra fields.
-Example in the code below. 
+Example in the code below.
 
 #### Code Example
 
 ```python
 import logging
 import logging.config
+
 # If you're using a serverless function, uncomment.
 # from logzio.flusher import LogzioFlusher
 
@@ -153,48 +181,54 @@ import logging.config
 logging.config.dictConfig(LOGGING)
 logger = logging.getLogger('superAwesomeLogzioLogger')
 
+
 # If you're using a serverless function, uncomment.
 # @LogzioFlusher(logger)
 def my_func():
     logger.info('Test log')
-    logger.warn('Warning')
+    logger.warning('Warning')
 
     try:
-        1/0
+        1 / 0
     except:
         logger.exception("Supporting exceptions too!")
 
-# Example additional code that demonstrates how to dynamically add/remove fields within the code, make sure class is imported.
+    # Example additional code that demonstrates how to dynamically add/remove fields within the code, make sure class is imported.
 
     logger.info("Test log")  # Outputs: {"message":"Test log"}
-    
-    extra_fields = {"foo":"bar","counter":1}
+
+    extra_fields = {"foo": "bar", "counter": 1}
     logger.addFilter(ExtraFieldsLogFilter(extra_fields))
     logger.warning("Warning test log")  # Outputs: {"message":"Warning test log","foo":"bar","counter":1}
-    
-    error_fields = {"err_msg":"Failed to run due to exception.","status_code":500}
+
+    error_fields = {"err_msg": "Failed to run due to exception.", "status_code": 500}
     logger.addFilter(ExtraFieldsLogFilter(error_fields))
-    logger.error("Error test log")  # Outputs: {"message":"Error test log","foo":"bar","counter":1,"err_msg":"Failed to run due to exception.","status_code":500}
-    
+    logger.error(
+        "Error test log")  # Outputs: {"message":"Error test log","foo":"bar","counter":1,"err_msg":"Failed to run due to exception.","status_code":500}
+
     # If you'd like to remove filters from future logs using the logger.removeFilter option:
     logger.removeFilter(ExtraFieldsLogFilter(error_fields))
-    logger.debug("Debug test log") # Outputs: {"message":"Debug test log","foo":"bar","counter":1}
+    logger.debug("Debug test log")  # Outputs: {"message":"Debug test log","foo":"bar","counter":1}
 
 ```
 
 #### Extra Fields
-In case you need to dynamic metadata to a speific log and not [dynamically to the logger](#dynamic-extra-fields), other than the constant metadata from the formatter, you can use the "extra" parameter.
-All key values in the dictionary passed in "extra" will be presented in Logz.io as new fields in the log you are sending.
+
+In case you need to dynamic metadata to a speific log and not [dynamically to the logger](#dynamic-extra-fields), other
+than the constant metadata from the formatter, you can use the "extra" parameter.
+All key values in the dictionary passed in "extra" will be presented in Logz.io as new fields in the log you are
+sending.
 Please note, that you cannot override default fields by the python logger (i.e. lineno, thread, etc..)
 For example:
 
 ```python
-logger.info('Warning', extra={'extra_key':'extra_value'})
+logger.info('Warning', extra={'extra_key': 'extra_value'})
 ```
 
 #### Trace context
 
-If you're sending traces with OpenTelemetry instrumentation (auto or manual), you can correlate your logs with the trace context.
+If you're sending traces with OpenTelemetry instrumentation (auto or manual), you can correlate your logs with the trace
+context.
 That way, your logs will have traces data in it, such as service name, span id and trace id.
 
 Make sure to install the OpenTelemetry logging instrumentation dependecy by running the following command:
@@ -202,6 +236,7 @@ Make sure to install the OpenTelemetry logging instrumentation dependecy by runn
 ```shell
 pip install logzio-python-handler[opentelemetry-logging]
 ```
+
 To enable this feature, set the `add_context` param in your handler configuration to `True`, like in this example:
 
 ```python
@@ -239,6 +274,7 @@ LOGGING = {
 ```
 
 #### Django configuration
+
 ```python
 LOGGING = {
     'version': 1,
@@ -284,49 +320,47 @@ LOGGING = {
 
 ```
 
-
 ## Release Notes
-- 4.1.1
-  - Fix flusher issues with serverless
-- 4.1.0
-  - Add ability to dynamically attach extra fields to the logs.
-  - Import opentelemetry logging dependency only if trace context is enabled and dependency is installed manually.
-    - Updated `opentelemetry-instrumentation-logging==0.39b0`
-  - Updated `setuptools>=68.0.0`
-  - Added tests for Python versions: 3.9, 3.10, 3.11
-- 4.0.2
-  - Fix bug for logging exceptions ([#76](https://github.com/logzio/logzio-python-handler/pull/76))
-- 4.0.1
-  - Updated `protobuf>=3.20.2`.
-  - Added dependency `setuptools>=65.5.1`
-  
-- 4.0.0
-  - Add ability to automatically attach trace context to the logs.
 
+- 4.1.1
+    - Fix flusher issues with serverless
+- 4.1.0
+    - Add ability to dynamically attach extra fields to the logs.
+    - Import opentelemetry logging dependency only if trace context is enabled and dependency is installed manually.
+        - Updated `opentelemetry-instrumentation-logging==0.39b0`
+    - Updated `setuptools>=68.0.0`
+    - Added tests for Python versions: 3.9, 3.10, 3.11
+- 4.0.2
+    - Fix bug for logging exceptions ([#76](https://github.com/logzio/logzio-python-handler/pull/76))
+- 4.0.1
+    - Updated `protobuf>=3.20.2`.
+    - Added dependency `setuptools>=65.5.1`
+
+- 4.0.0
+    - Add ability to automatically attach trace context to the logs.
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>
 
-
 - 3.1.1
-  - Bug fixes (issue #68, exception message formatting)
-  - Added CI: Tests and Auto release
-  
+    - Bug fixes (issue #68, exception message formatting)
+    - Added CI: Tests and Auto release
+
 - 3.1.0
     - Bug fixes
     - Retry number and timeout is now configurable
-    
+
 - 3.0.0
     - Deprecated `python2.7` & `python3.4`
     - Changed log levels on `_flush_queue()` method (@hilsenrat)
 
 - 2.0.15
     - Added flusher decorator for serverless platforms(@mcmasty)
-    - Add support for `python3.7` and `python3.8` 
+    - Add support for `python3.7` and `python3.8`
 
-- 2.0.13 
+- 2.0.13
     - Add support for `pypy` and `pypy3`(@rudaporto-olx)
-    - Add timeout for requests.post() (@oseemann) 
+    - Add timeout for requests.post() (@oseemann)
 - 2.0.12 - Support disable logs local backup
 - 2.0.11 - Completely isolate exception from the message
 - 2.0.10 - Not ignoring formatting on exceptions
@@ -340,11 +374,12 @@ LOGGING = {
 - 2.0.2 - Support for formatted messages (Thanks @johnraz!)
 - 2.0.1 - Added __all__ to __init__.py, so support * imports
 - 2.0.0 - Production, stable release.
-    - *BREAKING* - Configuration option logs_drain_count was removed, and the order of the parameters has changed for better simplicity. Please review the parameters section above.
-    - Introducing the LogzioSender class, which is generic and can be used without the handler wrap to ship raw data to Logz.io. Just create a new instance of the class, and use the append() method.
+    - *BREAKING* - Configuration option logs_drain_count was removed, and the order of the parameters has changed for
+      better simplicity. Please review the parameters section above.
+    - Introducing the LogzioSender class, which is generic and can be used without the handler wrap to ship raw data to
+      Logz.io. Just create a new instance of the class, and use the append() method.
     - Simplifications and Robustness
     - Full testing framework
 - 1.X - Beta versions
-  
 
 </details>

--- a/logzio/flusher.py
+++ b/logzio/flusher.py
@@ -17,4 +17,5 @@ class LogzioFlusher(logging.Logger):
                 raise
             finally:
                 [h.flush() for h in self.logger.handlers]
+
         return wrapper

--- a/logzio/handler.py
+++ b/logzio/handler.py
@@ -1,12 +1,12 @@
-import sys
+import datetime
 import json
 import logging
-import datetime
-import traceback
 import logging.handlers
+import sys
+import traceback
 
-from .sender import LogzioSender
 from .exceptions import LogzioException
+from .sender import LogzioSender
 
 
 class ExtraFieldsLogFilter(logging.Filter):
@@ -41,7 +41,8 @@ class LogzioHandler(logging.Handler):
 
         if add_context:
             try:
-                from opentelemetry.instrumentation.logging import LoggingInstrumentor
+                from opentelemetry.instrumentation.logging import \
+                    LoggingInstrumentor
                 LoggingInstrumentor().instrument(set_logging_format=True)
             except ImportError:
                 print("""Can't add trace context.
@@ -104,7 +105,7 @@ pip install 'logzio-python-handler[opentelemetry-logging]'""")
         return '\n'.join(traceback.format_exception(*exc_info))
 
     def format_message(self, message):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         timestamp = now.strftime('%Y-%m-%dT%H:%M:%S') + \
                     '.%03d' % (now.microsecond / 1000) + 'Z'
 

--- a/logzio/logger.py
+++ b/logzio/logger.py
@@ -1,5 +1,5 @@
-import sys
 import logging
+import sys
 
 
 def get_logger(debug):

--- a/logzio/sender.py
+++ b/logzio/sender.py
@@ -1,11 +1,10 @@
 # This class is responsible for handling all asynchronous Logz.io's
 # communication
-import sys
 import json
-
-from time import sleep
+import sys
 from datetime import datetime
 from threading import Thread, enumerate
+from time import sleep
 
 import requests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.27.0
 protobuf>=3.20.2
 setuptools>=68.0.0  # not directly required, pinned to avoid a vulnerability
+future>=0.18.3  # used in tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-universal=1
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 setup(
     name="logzio-python-handler",
-    version='4.1.1',
+    version='4.1.2',
     description="Logging handler to send logs to your Logz.io account with bulk SSL",
     keywords="logging handler logz.io bulk https",
     author="roiravhon",

--- a/tests/mockLogzioListener/listener.py
+++ b/tests/mockLogzioListener/listener.py
@@ -73,7 +73,7 @@ class MockLogzioListener:
         return len(self.logs_list)
 
     def clear_logs_buffer(self):
-        self.logs_list[:] = []
+        self.logs_list.clear()
 
     def set_server_error(self):
         self.persistent_flags.set_server_error()

--- a/tests/mockLogzioListener/listener.py
+++ b/tests/mockLogzioListener/listener.py
@@ -1,9 +1,8 @@
 # noinspection PyUnresolvedReferences
-import future
 import socket
-
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
+
 from .logsList import logs_list
 from .persistentFlags import persistent_flags
 

--- a/tests/mockLogzioListener/listener.py
+++ b/tests/mockLogzioListener/listener.py
@@ -1,4 +1,5 @@
 # noinspection PyUnresolvedReferences
+import future
 import socket
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread

--- a/tests/mockLogzioListener/persistentFlags.py
+++ b/tests/mockLogzioListener/persistentFlags.py
@@ -15,4 +15,5 @@ class PersistentFlags:
     def get_server_error(self):
         return self.server_error
 
+
 persistent_flags = PersistentFlags()

--- a/tests/test_add_context.py
+++ b/tests/test_add_context.py
@@ -1,8 +1,8 @@
 import fnmatch
+import json
 import logging.config
 import os
 import time
-import json
 from unittest import TestCase
 
 from .mockLogzioListener import listener

--- a/tests/test_extra_fields.py
+++ b/tests/test_extra_fields.py
@@ -1,10 +1,12 @@
 import fnmatch
+import json
 import logging.config
 import os
 import time
-import json
 from unittest import TestCase
+
 from logzio.handler import ExtraFieldsLogFilter
+
 from .mockLogzioListener import listener
 
 
@@ -108,7 +110,7 @@ class TestExtraFieldsFilter(TestCase):
         log_message = "this log should have additional fields"
         self.logger.info(log_message)
 
-        extra_fields = {"counter":1}
+        extra_fields = {"counter": 1}
         self.logger.addFilter(ExtraFieldsLogFilter(extra=extra_fields))
         filtered_log_message = "this log should have multiple additional fields"
         self.logger.info(filtered_log_message)

--- a/tests/test_logzioHandler.py
+++ b/tests/test_logzioHandler.py
@@ -1,11 +1,9 @@
+import logging
 import os
+import re
+import sys
 from unittest import TestCase
 
-import logging
-
-import sys
-
-import re
 from logzio.handler import LogzioHandler
 
 
@@ -140,7 +138,7 @@ class TestLogzioHandler(TestCase):
     def test_exception(self):
         formatter = logging.Formatter('{"tags": ["staging", "experimental"], "appname": "my-service"}', validate=False)
         self.handler.setFormatter(formatter)
-        
+
         try:
             raise ValueError("oops.")
         except:

--- a/tests/test_logzioHandler.py
+++ b/tests/test_logzioHandler.py
@@ -44,6 +44,7 @@ class TestLogzioHandler(TestCase):
                 'message': 'this is a test: moo.',
                 'path_name': 'handler_test.py',
                 'severity': 'NOTSET',
+                'taskName': None,
                 'type': 'python'
             }
         )
@@ -72,6 +73,7 @@ class TestLogzioHandler(TestCase):
                 'logger': 'my-logger',
                 'message': 'this is a test: moo.',
                 'path_name': 'handler_test.py',
+                'taskName': None,
                 'type': 'python'
             }
         )
@@ -102,6 +104,7 @@ class TestLogzioHandler(TestCase):
                 'logger': 'my-logger',
                 'message': 'this is a test: moo.',
                 'path_name': 'handler_test.py',
+                'taskName': None,
                 'type': 'python',
                 'extra_key': 'extra_value'
             }
@@ -131,6 +134,7 @@ class TestLogzioHandler(TestCase):
                 'logger': 'my-logger',
                 'message': 'this is a test: moo.',
                 'path_name': 'handler_test.py',
+                'taskName': None,
                 'type': 'python'
             }
         )
@@ -171,6 +175,7 @@ class TestLogzioHandler(TestCase):
                 'message': 'exception test:',
                 'exception': 'Traceback (most recent call last):\n\n  File "", in test_exception\n    raise ValueError("oops.")\n\nValueError: oops.\n',
                 'path_name': 'handler_test.py',
+                'taskName': None,
                 'type': 'python',
                 'tags': ['staging', 'experimental']
             },

--- a/tests/test_logzioSender.py
+++ b/tests/test_logzioSender.py
@@ -104,7 +104,7 @@ class TestLogzioSender(TestCase):
         # Make sure no file is present
         self.assertEqual(len(_find("logzio-failures-*.txt", ".")), 0)
 
-        time.sleep(self.retries_no*self.retry_timeout*2*2)  # All of the retries
+        time.sleep(self.retries_no * self.retry_timeout * 2 * 2)  # All of the retries
 
         failure_files = _find("logzio-failures-*.txt", ".")
         self.assertEqual(len(failure_files), 1)
@@ -122,7 +122,7 @@ class TestLogzioSender(TestCase):
         # Make sure no file is present
         self.assertEqual(len(_find("logzio-failures-*.txt", ".")), 0)
 
-        time.sleep(self.retries_no*self.retry_timeout)  # All of the retries
+        time.sleep(self.retries_no * self.retry_timeout)  # All of the retries
 
         # Make sure no file was created
         self.assertEqual(len(_find("logzio-failures-*.txt", ".")), 0)

--- a/tests/test_logzioSender.py
+++ b/tests/test_logzioSender.py
@@ -23,7 +23,7 @@ class TestLogzioSender(TestCase):
         self.logzio_listener = listener.MockLogzioListener()
         self.logzio_listener.clear_logs_buffer()
         self.logzio_listener.clear_server_error()
-        self.logs_drain_timeout = 1
+        self.logs_drain_timeout = 2
         self.retries_no = 4
         self.retry_timeout = 2
 

--- a/tests/test_logzioSender.py
+++ b/tests/test_logzioSender.py
@@ -23,7 +23,7 @@ class TestLogzioSender(TestCase):
         self.logzio_listener = listener.MockLogzioListener()
         self.logzio_listener.clear_logs_buffer()
         self.logzio_listener.clear_server_error()
-        self.logs_drain_timeout = 2
+        self.logs_drain_timeout = 3
         self.retries_no = 4
         self.retry_timeout = 2
 
@@ -122,7 +122,7 @@ class TestLogzioSender(TestCase):
         # Make sure no file is present
         self.assertEqual(len(_find("logzio-failures-*.txt", ".")), 0)
 
-        time.sleep(self.retries_no * self.retry_timeout)  # All of the retries
+        time.sleep(self.retries_no * self.retry_timeout * 2 * 2)  # All of the retries
 
         # Make sure no file was created
         self.assertEqual(len(_find("logzio-failures-*.txt", ".")), 0)


### PR DESCRIPTION
`datetime.utcnow()` is [deprecated](https://github.com/python/cpython/blob/3.12/Lib/_pydatetime.py#L1826), so I replaced it with `datetime.datetime.now(datetime.timezone.utc)`: 
https://github.com/akiva-skolnik/logzio-python-handler/blob/master/logzio/handler.py#L108